### PR TITLE
Merge with new control scheme

### DIFF
--- a/docker/Dockerfile.deploy
+++ b/docker/Dockerfile.deploy
@@ -195,7 +195,7 @@ COPY ./src /home/workspace/src
 WORKDIR /home/workspace
 
 # Install dependencies for the rover software
-RUN /bin/bash -c "source /opt/ros/humble/setup.bash && \
+RUN /bin/bash -c "apt-get update && source /opt/ros/humble/setup.bash && \
     source ${ROS2_WRAPPER_FOLDER}/install/setup.bash && \
     rosdep update && \
     rosdep install --from-paths src --ignore-src -r -y --rosdistro humble"

--- a/docker/docker-compose.new.yaml
+++ b/docker/docker-compose.new.yaml
@@ -38,6 +38,48 @@ services:
       - /dev/video2:/dev/video2
       - /dev/video3:/dev/video3
 
+  cameras:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.new
+      target: production
+      args:
+        L4T_VERSION_MAJOR: 36 # jetpack version 36.4.0 
+        L4T_VERSION_MINOR: 4
+        L4T_VERSION_PATCH: 0
+        ZED_SDK_MAJOR: 5 # ZED SDK version 5.0.3
+        ZED_SDK_MINOR: 0
+        ZED_SDK_PATCH: 3
+        ROS2_WRAPPER_FOLDER: /home/ros2_ws
+        ZED_ROS2_WRAPPER_BRANCH: master
+        ZED_ROS2_WRAPPER_URL: https://github.com/stereolabs/zed-ros2-wrapper.git
+    container_name: rover-cameras
+    volumes:
+      - ../src:/home/workspace/src
+      - /tmp/argus_socket:/tmp/argus_socket
+      - /lib/modules/5.15.148-tegra:/lib/modules/5.15.148-tegra
+      - /dev/:/dev/
+      - /usr/local/zed/resources/:/usr/local/zed/resources/
+      - /tmp/.X11-unix/:/tmp/.X11-unix
+      - /dev/shm:/dev/shm
+    working_dir: /home/workspace
+    stdin_open: true
+    tty: true
+    environment:
+      - ROS_DOMAIN_ID=0
+    network_mode: host
+    privileged: true
+    runtime: nvidia
+    restart: unless-stopped
+    devices:
+      - /dev:/dev
+      - /dev/video0:/dev/video0
+      - /dev/video1:/dev/video1
+      - /dev/video2:/dev/video2
+      - /dev/video3:/dev/video3
+    entrypoint: ["/bin/bash"]
+    command: ["-c", "source /opt/ros/humble/setup.bash && source /home/workspace/install/setup.bash && ros2 launch gorm_sensors cameras.launch.py"]
+
   rover-deploy:
     build:
       context: ..

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -10,3 +10,4 @@ else
   sudo modprobe iptable_raw
   docker compose --file docker-compose.yaml up rover --detach --build --remove-orphans
 fi
+

--- a/src/rover/gorm_teleop/launch/teleop.launch.py
+++ b/src/rover/gorm_teleop/launch/teleop.launch.py
@@ -19,6 +19,6 @@ def generate_launch_description():
     )
 
     ld.add_action(joy_to_cmd_vel_node)
-    ld.add_action(joy_node)
+    #ld.add_action(joy_node)
 
     return ld


### PR DESCRIPTION
This pull request introduces the new `cameras` service to the Docker Compose configuration for the rover software, refines the deployment Dockerfile to improve dependency installation, and contains a minor launch configuration change for teleoperation. The main changes focus on expanding camera support and improving the build process for ROS2-based containers.

**Camera Service Addition and Configuration:**

* Added a new `cameras` service to `docker/docker-compose.new.yaml`, including build arguments for Jetpack and ZED SDK versions, extensive device and volume mounts, and an entrypoint to launch camera-related ROS2 nodes.

**Build and Dependency Improvements:**

* Updated the `docker/Dockerfile.deploy` build step to run `apt-get update` before sourcing ROS2 environments and installing dependencies, ensuring packages are up to date before installation.

**Teleop Launch Configuration:**

* Commented out the action that launches `joy_node` in `src/rover/gorm_teleop/launch/teleop.launch.py`, likely to prevent duplicate joystick node launches or to disable joystick input temporarily.

**Script Minor Update:**

* Added a trailing newline to `docker/run.sh` for improved formatting and potential compatibility with some shell environments.