### PR TITLE
feat: ERC2025 - New control scheme

### DIFF
--- a/src/rover/gorm_base_control/gorm_base_control/ackermann_node.py
+++ b/src/rover/gorm_base_control/gorm_base_control/ackermann_node.py
@@ -36,7 +36,7 @@ class AckermannNode(Node):
         linear_vel = msg.linear.x
         angular_vel = msg.angular.z
 
-        if msg.angular.x > 0:
+        if abs(msg.angular.x) > 0:
             steering_angles, wheel_velocities = self.turn_on_spot(angular_vel)
         else:
             # Your Ackermann function here, assume it returns steering_angles and wheel_velocities
@@ -54,7 +54,7 @@ class AckermannNode(Node):
             
 
 
-    def turn_on_spot(ang_vel, wheel_radius=0.12, d_lr=0.894, d_fr=0.77, L=0.849, offset=-0.0135):
+    def turn_on_spot(self, ang_vel, wheel_radius=0.12, d_lr=0.894, d_fr=0.77, L=0.849, offset=-0.0135):
         """
         Turn the vehicle on the spot (pure rotation).
         Returns steering angles and wheel velocities.

--- a/src/rover/gorm_base_control/gorm_base_control/ackermann_node.py
+++ b/src/rover/gorm_base_control/gorm_base_control/ackermann_node.py
@@ -59,7 +59,7 @@ class AckermannNode(Node):
         Turn the vehicle on the spot (pure rotation).
         Returns steering angles and wheel velocities.
         """
-        turn_direction = -1 if ang_vel < 0 else 1
+        turn_direction = ang_vel
 
         # Steering angles (wheels at max deflection)
         theta_FL = -np.pi/4

--- a/src/rover/gorm_base_control/gorm_base_control/ackermann_node.py
+++ b/src/rover/gorm_base_control/gorm_base_control/ackermann_node.py
@@ -59,8 +59,6 @@ class AckermannNode(Node):
         Turn the vehicle on the spot (pure rotation).
         Returns steering angles and wheel velocities.
         """
-        turn_direction = ang_vel
-
         # Steering angles (wheels at max deflection)
         theta_FL = -np.pi/4
         theta_FR = np.pi/4
@@ -69,15 +67,14 @@ class AckermannNode(Node):
         steering_angles = np.array([theta_FL, theta_FR, theta_RL, theta_RR]) * -1
 
         # Wheel velocities for pure spin
-        V_FL = -(ang_vel)*turn_direction
-        V_FR = -(ang_vel)*turn_direction
-        V_ML = -(ang_vel)*turn_direction
-        V_MR = -(ang_vel)*turn_direction
-        V_RL = -(ang_vel)*turn_direction
-        V_RR = -(ang_vel)*turn_direction
+        V_FL = -(ang_vel)
+        V_FR = -(ang_vel)
+        V_ML = -(ang_vel)
+        V_MR = -(ang_vel)
+        V_RL = -(ang_vel)
+        V_RR = -(ang_vel)
 
         wheel_velocities = np.array([V_FL, V_FR, V_ML, V_MR, V_RL, V_RR]) / (wheel_radius * 2)
-
         return steering_angles, wheel_velocities
 
 

--- a/src/rover/gorm_base_control/gorm_base_control/ackermann_node.py
+++ b/src/rover/gorm_base_control/gorm_base_control/ackermann_node.py
@@ -59,7 +59,6 @@ class AckermannNode(Node):
         Turn the vehicle on the spot (pure rotation).
         Returns steering angles and wheel velocities.
         """
-        direction = -1 if lin_vel < 0 else 1
         turn_direction = -1 if ang_vel < 0 else 1
 
         # Steering angles (wheels at max deflection)

--- a/src/rover/gorm_teleop/gorm_teleop/joy_to_cmd_vel_node.py
+++ b/src/rover/gorm_teleop/gorm_teleop/joy_to_cmd_vel_node.py
@@ -80,6 +80,7 @@ class JoyToVelNode(Node):
             return 0.8
         if msg.buttons[3]==1:
             return 0.5
+        return self.speed_multi
 
     def circle_to_square(self, x, y):
         # Ensure the point (x, y) lies within the unit circle

--- a/src/rover/gorm_teleop/gorm_teleop/joy_to_cmd_vel_node.py
+++ b/src/rover/gorm_teleop/gorm_teleop/joy_to_cmd_vel_node.py
@@ -26,6 +26,7 @@ class JoyToVelNode(Node):
         
         self.linear_vel = 0.0
         self.angular_vel = 0.0
+        self.speed_multi = 1
 
         self.get_logger().info("Joy to vel converter node started successfully")
 
@@ -35,16 +36,31 @@ class JoyToVelNode(Node):
         
         linear_vel = msg.axes[1] # Left stick up/down
         angular_vel = msg.axes[0] # Left stick left/right
+        right_stick_x = msg.axes[3] # right stick left/right
+
+
+        self.speed_multi = self.check_ABXY_pressed(msg)
+   
 
         # Strech the circle to a square
         linear_vel, angular_vel = self.circle_to_square(linear_vel, angular_vel)
 
-        # Create and publish the message
-        twist = Twist()
-        twist.linear.x = linear_vel
-        twist.angular.z = angular_vel
+        # Turn on point
+        if right_stick_x>0:
+            # Create and publish the message
+            twist = Twist()
+            twist.linear.x = linear_vel*self.speed_multi
+            twist.angular.z = angular_vel*self.speed_multi
 
-        self.publisher_.publish(twist)
+            self.publisher_.publish(twist)
+        else:
+            # Create and publish the message
+            twist = Twist()
+            twist.angular.z = right_stick_x*self.speed_multi
+
+            self.publisher_.publish(twist)
+
+
 
         # If Y button is pressed, stop the robot
         # TODO - Implement a service that stop the robot over can bus
@@ -53,6 +69,17 @@ class JoyToVelNode(Node):
         #     twist.linear.x = 0
         #     twist.angular.z = 0
         #     self.publisher_.publish(twist)
+
+
+    def check_ABXY_pressed(self, msg):
+        if msg.buttons[0]==1:
+            return 1.0
+        if msg.buttons[1]==1:
+            return 0.3
+        if msg.buttons[2]==1:
+            return 0.8
+        if msg.buttons[3]==1:
+            return 0.5
 
     def circle_to_square(self, x, y):
         # Ensure the point (x, y) lies within the unit circle

--- a/src/rover/gorm_teleop/gorm_teleop/joy_to_cmd_vel_node.py
+++ b/src/rover/gorm_teleop/gorm_teleop/joy_to_cmd_vel_node.py
@@ -49,8 +49,8 @@ class JoyToVelNode(Node):
         if abs(right_stick_x)>0.0001:
             # Create and publish the message
             twist = Twist()
-            twist.angular.z = right_stick_x*self.speed_multi
-            twist.angular.x = right_stick_x*self.speed_multi
+            twist.angular.z = right_stick_x*self.speed_multi*4
+            twist.angular.x = right_stick_x*self.speed_multi*4
             
 
             self.publisher_.publish(twist)

--- a/src/rover/gorm_teleop/gorm_teleop/joy_to_cmd_vel_node.py
+++ b/src/rover/gorm_teleop/gorm_teleop/joy_to_cmd_vel_node.py
@@ -46,7 +46,7 @@ class JoyToVelNode(Node):
         linear_vel, angular_vel = self.circle_to_square(linear_vel, angular_vel)
 
         # Turn on point
-        if right_stick_x>0.01:
+        if abs(right_stick_x)>0.0001:
             # Create and publish the message
             twist = Twist()
             twist.angular.z = right_stick_x*self.speed_multi

--- a/src/rover/gorm_teleop/gorm_teleop/joy_to_cmd_vel_node.py
+++ b/src/rover/gorm_teleop/gorm_teleop/joy_to_cmd_vel_node.py
@@ -46,17 +46,19 @@ class JoyToVelNode(Node):
         linear_vel, angular_vel = self.circle_to_square(linear_vel, angular_vel)
 
         # Turn on point
-        if right_stick_x>0:
+        if right_stick_x>0.01:
             # Create and publish the message
             twist = Twist()
-            twist.linear.x = linear_vel*self.speed_multi
-            twist.angular.z = angular_vel*self.speed_multi
+            twist.angular.z = right_stick_x*self.speed_multi
+            twist.angular.x = right_stick_x*self.speed_multi
+            
 
             self.publisher_.publish(twist)
         else:
             # Create and publish the message
             twist = Twist()
-            twist.angular.z = right_stick_x*self.speed_multi
+            twist.linear.x = linear_vel*self.speed_multi
+            twist.angular.z = angular_vel*self.speed_multi
 
             self.publisher_.publish(twist)
 


### PR DESCRIPTION
This pull request introduces significant improvements to the rover's teleoperation and base control logic, focusing on enabling "turn on spot" functionality, refining speed control via joystick buttons, and improving safety with quicker timeout handling. The changes are primarily in the `ackermann_node.py` and `joy_to_cmd_vel_node.py` files.

**Teleoperation and Control Enhancements:**

* Added "turn on spot" capability: The rover can now spin in place when the right joystick is moved, with corresponding updates to both teleop and base control nodes to handle this new command and calculate appropriate wheel velocities and steering angles. [[1]](diffhunk://#diff-99a98e638a5b71745a47280f5753e18088a81c8eeee40ded315fe79038f995eeR39-R41) [[2]](diffhunk://#diff-99a98e638a5b71745a47280f5753e18088a81c8eeee40ded315fe79038f995eeR54-R83) [[3]](diffhunk://#diff-3da1bdc584d46d2d04d850de1b8f872f6bb90d436deddfdbd3ba0e373da0834dR39-R66)
* Dynamic speed adjustment: The teleop node now supports changing speed multipliers based on which ABXY button is pressed, allowing for quick and intuitive speed control during operation. [[1]](diffhunk://#diff-3da1bdc584d46d2d04d850de1b8f872f6bb90d436deddfdbd3ba0e373da0834dR29) [[2]](diffhunk://#diff-3da1bdc584d46d2d04d850de1b8f872f6bb90d436deddfdbd3ba0e373da0834dR75-R86)

**Safety and Control Logic Improvements:**

* Reduced command timeout: The base control node now stops the rover if no command is received for 0.5 seconds instead of 3 seconds, improving safety and responsiveness.
* Ackermann steering refinement: Ensured the minimum turning radius is respected for more reliable and safer maneuvering, especially at low velocities.