### PR TITLE
Feature/twist mux

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -186,7 +186,7 @@ RUN pip3 install tritonclient[all]
 ###         Install EXTRAS       ###
 #####################################
 
-RUN apt-get update && apt-get install -y ros-humble-rosbridge-server ros-humble-rmw-zenoh-cpp
+RUN apt-get update && apt-get install -y ros-humble-rosbridge-server ros-humble-rmw-zenoh-cpp ros-humble-twist-mux
 
 # Clean up
 RUN rm -rf /var/lib/apt/lists/*

--- a/src/rover/gorm_bringup/README_twist_mux.md
+++ b/src/rover/gorm_bringup/README_twist_mux.md
@@ -1,0 +1,188 @@
+# GORM Rover twist_mux Control System
+
+## Overview
+
+The GORM rover now uses the ROS 2 `twist_mux` multiplexer node to robustly switch between different control sources. This provides a clean, modular approach to handling multiple velocity command inputs with automatic priority-based switching and manual override capabilities.
+
+## Architecture
+
+### Control Flow
+```
+Input Sources → twist_mux → Base Control → Motor Commands
+```
+
+1. **Input Sources** (Publishers):
+   - **Local Joystick**: `joy_node` publishes `sensor_msgs/Joy` to `/joy/joy`. A `joy_to_cmd_vel_node` instance processes this into `geometry_msgs/Twist` on `/joystick/cmd_vel` (Priority: 100).
+   - **Remote Control**: A remote `joy_node` publishes `sensor_msgs/Joy` to `/remote/joy`. A second `joy_to_cmd_vel_node` instance on the rover processes this into `geometry_msgs/Twist` on `/remote/cmd_vel` (Priority: 90).
+   - **Autonomous Navigation**: The RL navigation node publishes `geometry_msgs/Twist` directly to `/autonomous/cmd_vel` (Priority: 10).
+
+2. **Central Multiplexer**:
+   - `twist_mux` subscribes to all input topics and selects one based on priority
+   - Publishes selected velocity command to `/cmd_vel`
+
+3. **Robot Control**:
+   - `ackermann_node` subscribes to `/cmd_vel` and converts to motor commands
+
+### Priority System
+
+- **Joystick**: Priority 100 (Highest) - Direct manual control takes precedence
+- **Remote**: Priority 90 - Remote joystick control  
+- **Autonomous**: Priority 10 (Lowest) - Autonomous navigation runs when no manual control is active
+
+### Safety Features
+
+- **Timeout Protection**: Each input has a 0.5-second timeout. If no messages are received within the timeout, that source is automatically deactivated
+- **Graceful Degradation**: Robot stops safely if all active sources disconnect
+
+## Usage
+
+### Automatic Mode Switching
+
+The system automatically selects the active control source with the highest priority:
+
+1. Move joystick → Joystick control takes over
+2. Stop using joystick (timeout after 0.5s) → Remote control activates (if publishing)
+3. No manual control → Autonomous navigation runs
+
+### Manual Mode Switching (Service Calls)
+
+You can manually lock to a specific control source using ROS 2 services:
+
+#### Lock to Autonomous Mode
+```bash
+ros2 service call /twist_mux/change_topic twist_mux_msgs/srv/SetMux "{topic: 'autonomous'}"
+```
+
+#### Lock to Joystick Mode
+```bash
+ros2 service call /twist_mux/change_topic twist_mux_msgs/srv/SetMux "{topic: 'joystick'}"
+```
+
+#### Lock to Remote Mode
+```bash
+ros2 service call /twist_mux/change_topic twist_mux_msgs/srv/SetMux "{topic: 'remote'}"
+```
+
+#### Unlock (Return to Automatic Priority-based Switching)
+```bash
+ros2 service call /twist_mux/change_topic twist_mux_msgs/srv/SetMux "{topic: ''}"
+```
+
+### Monitor Current Mode
+
+Check which control source is currently active:
+
+```bash
+ros2 topic echo /twist_mux/selected
+```
+
+## Launch Files
+
+### Main System Launch
+```bash
+# Launches complete system with twist_mux
+ros2 launch gorm_bringup bringup_teleop.launch.py
+```
+
+### Individual Components
+```bash
+# Just the control switching system
+ros2 launch gorm_bringup control_switch.launch.py
+
+# Just teleop (publishes to /joystick/cmd_vel and /remote/cmd_vel)
+ros2 launch gorm_teleop teleop.launch.py
+
+# Autonomous navigation (publishes to /autonomous/cmd_vel)
+ros2 launch gorm_navigation autonomous_navigation.launch.py
+```
+
+## Configuration Files
+
+The twist_mux configuration is in `gorm_bringup/config/twist_mux.yaml`:
+
+```yaml
+twist_mux:
+  ros__parameters:
+    cmd_vel_out: "cmd_vel_out"
+    topics:
+      joystick:
+        topic: "joystick/cmd_vel"
+        timeout: 0.5
+        priority: 100
+      remote:
+        topic: "remote/cmd_vel" 
+        timeout: 0.5
+        priority: 90
+      autonomous:
+        topic: "autonomous/cmd_vel"
+        timeout: 0.5
+        priority: 10
+```
+
+## Topics
+
+### Input Topics (twist_mux subscribes to these)
+- `/joystick/cmd_vel` - Local joystick control commands
+- `/remote/cmd_vel` - Remote joystick control commands  
+- `/autonomous/cmd_vel` - Autonomous navigation commands
+
+### Intermediate Topics
+- `/joy/joy` - Raw data from the local joystick
+- `/remote/joy` - Raw data from the remote joystick
+
+### Output Topics (twist_mux publishes to these)
+- `/cmd_vel` - Selected velocity commands sent to base control
+
+### Status Topics
+- `/twist_mux/selected` - Currently selected input topic
+- `/twist_mux/twist_stamped` - Selected twist commands with timestamp
+
+## Dependencies
+
+The system requires the `twist_mux` package:
+
+### ROS Package Dependencies
+- Added to `gorm_bringup/package.xml`: `<depend>twist_mux</depend>`
+
+### Docker/System Dependencies  
+- Added to `Dockerfile`: `ros-humble-twist-mux`
+
+### Manual Installation (if needed)
+```bash
+sudo apt update
+sudo apt install ros-humble-twist-mux
+```
+
+## Troubleshooting
+
+### No Movement
+1. Check if any control source is publishing:
+   ```bash
+   ros2 topic echo /joystick/cmd_vel
+   ros2 topic echo /autonomous/cmd_vel
+   ```
+
+2. Check twist_mux status:
+   ```bash
+   ros2 topic echo /twist_mux/selected
+   ```
+
+3. Verify base control is receiving commands:
+   ```bash
+   ros2 topic echo /cmd_vel
+   ```
+
+### Wrong Control Source Active
+- Use manual override service calls to lock to desired source
+- Check timeout settings in configuration file
+- Verify priority values are correct
+
+### Service Calls Not Working
+- Ensure twist_mux node is running:
+   ```bash
+   ros2 node list | grep twist_mux
+   ```
+- Check available services:
+   ```bash
+   ros2 service list | grep twist_mux
+   ```

--- a/src/rover/gorm_bringup/config/twist_mux.yaml
+++ b/src/rover/gorm_bringup/config/twist_mux.yaml
@@ -1,0 +1,16 @@
+twist_mux:
+  ros__parameters:
+    cmd_vel_out: "cmd_vel_out"
+    topics:
+      joystick:
+        topic: "joystick/cmd_vel"
+        timeout: 0.5
+        priority: 100
+      remote:
+        topic: "remote/cmd_vel"
+        timeout: 0.5
+        priority: 90
+      autonomous:
+        topic: "autonomous/cmd_vel"
+        timeout: 0.5
+        priority: 10

--- a/src/rover/gorm_bringup/launch/bringup_teleop.launch.py
+++ b/src/rover/gorm_bringup/launch/bringup_teleop.launch.py
@@ -24,21 +24,20 @@ def generate_launch_description():
         output='screen'
     )
 
-    # Joy node
-    joy_node = Node(
-        package='joy',
-        namespace='joy',
-        executable='joy_node',
-        name='joy_node',
-        output='screen'
+    # Include control switching (twist_mux) system
+    control_switch = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource([
+            os.path.join(get_package_share_directory('gorm_bringup'), 'launch'),
+            '/control_switch.launch.py'
+        ])
     )
 
-    # Joy to cmd_vel converter (if reimplemented in gorm_teleop)
-    joy_to_cmd_vel_node = Node(
-        package='gorm_teleop',
-        executable='joy_to_cmd_vel_node',
-        name='joy_to_cmd_vel_node',
-        output='screen'
+    # Include teleop system  
+    teleop_launch = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource([
+            os.path.join(get_package_share_directory('gorm_teleop'), 'launch'),
+            '/teleop.launch.py'
+        ])
     )
 
     # Web interface (includes rosbridge and web server)
@@ -49,8 +48,8 @@ def generate_launch_description():
         ])
     )
 
-    ld.add_action(joy_node)
-    ld.add_action(joy_to_cmd_vel_node)
+    ld.add_action(control_switch)
+    ld.add_action(teleop_launch) 
     ld.add_action(ackermann_node)
     ld.add_action(motor_driver_node)
     ld.add_action(web_interface)

--- a/src/rover/gorm_bringup/launch/control_switch.launch.py
+++ b/src/rover/gorm_bringup/launch/control_switch.launch.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+
+import os
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch_ros.actions import Node
+
+def generate_launch_description():
+    """
+    Launch file for twist_mux multiplexer to switch between joystick, remote, and autonomous control.
+    
+    This launch file sets up the twist_mux node with proper configuration and remappings
+    to handle multiple velocity command sources with priority-based switching.
+    """
+    
+    # Get the config file path
+    twist_mux_config = os.path.join(
+        get_package_share_directory('gorm_bringup'),
+        'config',
+        'twist_mux.yaml'
+    )
+    
+    # twist_mux node - central multiplexer for velocity commands
+    twist_mux_node = Node(
+        package='twist_mux',
+        executable='twist_mux',
+        name='twist_mux',
+        parameters=[twist_mux_config],
+        remappings=[
+            ('/cmd_vel_out', '/cmd_vel')  # Output directly to what base control expects
+        ],
+        output='screen'
+    )
+    
+    return LaunchDescription([
+        twist_mux_node,
+    ])

--- a/src/rover/gorm_bringup/package.xml
+++ b/src/rover/gorm_bringup/package.xml
@@ -10,6 +10,7 @@
   <depend>rclpy</depend>
   <depend>geometry_msgs</depend>
   <depend>std_msgs</depend>
+  <depend>twist_mux</depend>
   <depend>gorm_web_interface</depend>
   <depend>gorm_sensors</depend>
 

--- a/src/rover/gorm_navigation/gorm_navigation/rl_navigation_node.py
+++ b/src/rover/gorm_navigation/gorm_navigation/rl_navigation_node.py
@@ -12,7 +12,7 @@ provide autonomous navigation capabilities using trained RL models.
 Constraints:
 - Language: Python (suitable for high-level navigation logic)
 - Key Inputs: Depth images from ZED camera, goal position, robot pose
-- Key Outputs: Velocity commands to /cmd_vel topic
+- Key Outputs: Velocity commands to /autonomous/cmd_vel topic
 - Uses Triton Inference Server for RL model inference
 """
 
@@ -103,7 +103,7 @@ class GormRLNavigationNode(Node):
         
         # Setup Publishers
         self.velocity_publisher = self.create_publisher(
-            Twist, '/cmd_vel', 10)
+            Twist, '/autonomous/cmd_vel', 10)
         
         # Setup Subscribers
         # Subscribe to ZED depth topic

--- a/src/rover/gorm_navigation/launch/rl_navigation.launch.py
+++ b/src/rover/gorm_navigation/launch/rl_navigation.launch.py
@@ -57,14 +57,7 @@ def generate_launch_description():
             'depth_image_width': 160,
             'max_depth_value': 4.0,
             'enable_triton': LaunchConfiguration('enable_triton'),
-        }],
-        # remappings=[
-        #     # Remap topics to match your robot's actual topic names
-        #     ('/goal_pose', '/goal_pose'),
-        #     ('/amcl_pose', '/amcl_pose'),
-        #     ('/odom', '/odom'),
-        #     ('/cmd_vel', '/cmd_vel'),
-        # ]
+        }]
     )
     
     return LaunchDescription([

--- a/src/rover/gorm_teleop/gorm_teleop/joy_to_cmd_vel_node.py
+++ b/src/rover/gorm_teleop/gorm_teleop/joy_to_cmd_vel_node.py
@@ -10,25 +10,32 @@ import numpy as np
 class JoyToVelNode(Node):
     def __init__(self):
         super().__init__('joy_to_vel_converter')
+
+        # Declare parameters for input and output topics
+        self.declare_parameter('joy_topic', '/joy/joy')
+        self.declare_parameter('twist_topic', '/joystick/cmd_vel')
+
+        joy_topic = self.get_parameter('joy_topic').get_parameter_value().string_value
+        twist_topic = self.get_parameter('twist_topic').get_parameter_value().string_value
         
         # Subscriber
         self.subscription = self.create_subscription(
             Joy,
-            '/joy/joy',
+            joy_topic,
             self.listener_callback,
             10)
         
         # Publisher
         self.publisher_ = self.create_publisher(
             Twist,
-            '/cmd_vel',
+            twist_topic,
             10)
         
         self.linear_vel = 0.0
         self.angular_vel = 0.0
         self.speed_multi = 1
 
-        self.get_logger().info("Joy to vel converter node started successfully")
+        self.get_logger().info(f"Joy to vel converter node started. Subscribing to '{joy_topic}' and publishing to '{twist_topic}'.")
 
     def listener_callback(self, msg):
 

--- a/src/rover/gorm_teleop/launch/teleop.launch.py
+++ b/src/rover/gorm_teleop/launch/teleop.launch.py
@@ -2,23 +2,53 @@ from launch import LaunchDescription
 from launch_ros.actions import Node
 
 def generate_launch_description():
-    ld = LaunchDescription()
-
-    joy_to_cmd_vel_node = Node(
+    """
+    Launch file for teleop control, including local and remote joystick processing.
+    
+    This launch file starts two instances of the joy_to_cmd_vel_node:
+    1. For local joystick control, subscribing to /joy/joy and publishing to /joystick/cmd_vel.
+    2. For remote joystick control, subscribing to /remote/joy and publishing to /remote/cmd_vel.
+    """
+    launch_description = LaunchDescription()
+    
+    # Node for local joystick control
+    local_joy_to_cmd_vel_node = Node(
         package='gorm_teleop',
         executable='joy_to_cmd_vel_node',
-        name='joy_to_cmd_vel_node',
-        output='screen'
+        name='local_joy_to_cmd_vel_node',
+        output='screen',
+        parameters=[{
+            'joy_topic': '/local/joy',
+            'twist_topic': '/joystick/cmd_vel'
+        }]
     )
 
+    # Node for remote joystick control
+    remote_joy_to_cmd_vel_node = Node(
+        package='gorm_teleop',
+        executable='joy_to_cmd_vel_node',
+        name='remote_joy_to_cmd_vel_node',
+        output='screen',
+        parameters=[{
+            'joy_topic': '/remote/joy',
+            'twist_topic': '/remote/cmd_vel'
+        }]
+    )
+
+    # Local joy node
     joy_node = Node(
         package='joy',
         executable='joy_node',
         name='joy_node',
-        output='screen'
+        output='screen',
+        remappings=[
+            ('/joy/joy', '/local/joy')
+        ]
     )
 
-    ld.add_action(joy_to_cmd_vel_node)
-    ld.add_action(joy_node)
+    # Add actions to launch description
+    launch_description.add_action(local_joy_to_cmd_vel_node)
+    launch_description.add_action(remote_joy_to_cmd_vel_node)
+    launch_description.add_action(joy_node)
 
-    return ld
+    return launch_description


### PR DESCRIPTION
This pull request introduces a robust, priority-based velocity command multiplexer system for the GORM rover using the ROS 2 `twist_mux` package. The changes modularize control input handling, enabling seamless switching between local joystick, remote joystick, and autonomous navigation sources. The implementation includes new configuration, launch files, and documentation, as well as code updates to align all velocity command topics with the new architecture.

**Multiplexer System Integration**

* Added `twist_mux` as a dependency in `package.xml` and installed the corresponding system package in the Dockerfile to enable priority-based switching between velocity command sources. [[1]](diffhunk://#diff-1576792315dd6116d2e465b4a417b7c5e459bc1bbd7f557513d10479ac34583aR13) [[2]](diffhunk://#diff-f34da55ca08f1a30591d8b0b3e885bcc678537b2a9a4aadea4f190806b374ddcL189-R189)
* Introduced a new configuration file `twist_mux.yaml` specifying input topics, priorities, and timeouts for joystick, remote, and autonomous sources.
* Created `control_switch.launch.py` to launch the `twist_mux` node with appropriate configuration and topic remapping.

**Launch and System Architecture Updates**

* Updated `bringup_teleop.launch.py` to launch both the control switching (twist_mux) and teleop systems, replacing direct node launches for joystick input and conversion. [[1]](diffhunk://#diff-4319f1e968a1c947f393b740387b09f93cfb52de7f9621400520c1c161bd32f7L27-R40) [[2]](diffhunk://#diff-4319f1e968a1c947f393b740387b09f93cfb52de7f9621400520c1c161bd32f7L52-R52)
* Refactored `teleop.launch.py` to start two instances of the joystick-to-cmd_vel node: one for local joystick input and one for remote, each with explicit topic parameters and remappings.

**Node and Topic Standardization**

* Modified the `joy_to_cmd_vel_node.py` node to accept parameterized input/output topics, supporting flexible deployment for both local and remote joystick sources.
* Updated the RL navigation node to publish velocity commands to `/autonomous/cmd_vel` instead of `/cmd_vel`, aligning with the new multiplexer architecture. [[1]](diffhunk://#diff-2d15a5a45b167292c760cec4988abbb74dcb216f37ed680482444bda2c6e5601L15-R15) [[2]](diffhunk://#diff-2d15a5a45b167292c760cec4988abbb74dcb216f37ed680482444bda2c6e5601L106-R106)

**Documentation**

* Added a comprehensive `README_twist_mux.md` explaining the new control system architecture, usage, configuration, and troubleshooting steps.

---

**Multiplexer System Integration**
- Added `twist_mux` as a ROS and system dependency (`package.xml`, `Dockerfile`). [[1]](diffhunk://#diff-1576792315dd6116d2e465b4a417b7c5e459bc1bbd7f557513d10479ac34583aR13) [[2]](diffhunk://#diff-f34da55ca08f1a30591d8b0b3e885bcc678537b2a9a4aadea4f190806b374ddcL189-R189)
- Added `twist_mux.yaml` configuration file specifying input topics, priorities, and timeouts.
- Implemented `control_switch.launch.py` to launch the multiplexer node.

**Launch and Node Architecture**
- Updated `bringup_teleop.launch.py` to launch the new control switching and teleop systems. [[1]](diffhunk://#diff-4319f1e968a1c947f393b740387b09f93cfb52de7f9621400520c1c161bd32f7L27-R40) [[2]](diffhunk://#diff-4319f1e968a1c947f393b740387b09f93cfb52de7f9621400520c1c161bd32f7L52-R52)
- Refactored `teleop.launch.py` to handle both local and remote joystick input nodes with parameterized topics.

**Node and Topic Standardization**
- Parameterized input/output topics in `joy_to_cmd_vel_node.py` for flexible deployment.
- RL navigation node now publishes to `/autonomous/cmd_vel` to integrate with the multiplexer. [[1]](diffhunk://#diff-2d15a5a45b167292c760cec4988abbb74dcb216f37ed680482444bda2c6e5601L15-R15) [[2]](diffhunk://#diff-2d15a5a45b167292c760cec4988abbb74dcb216f37ed680482444bda2c6e5601L106-R106)

**Documentation**
- Added `README_twist_mux.md` detailing architecture, usage, configuration, and troubleshooting.

## ✅ Checklist – Functional & Integration Testing

- [ ] **Build & Launch**
  - Repo builds cleanly
  - `control_switch.launch.py` starts without errors

- [ ] **Topic Routing**
  - Local joystick publishes to `/local/cmd_vel`
  - Remote joystick publishes to `/remote/cmd_vel`
  - RL navigation publishes to `/autonomous/cmd_vel`
  - `twist_mux` outputs only on `/cmd_vel`

- [ ] **Priority Handling**
  - Higher-priority source overrides lower ones
  - Switching between local, remote, and autonomous works seamlessly
  - Timeout stops rover when active source is lost

- [ ] **Launch Files**
  - `bringup_teleop.launch.py` launches teleop + mux correctly
  - `teleop.launch.py` runs two joystick nodes without conflicts

- [ ] **Documentation**
  - `README_twist_mux.md` matches tested behavior

---

### Individual Control Sources
- [ ] Local Joystick: Rover moves correctly under local joystick control
- [ ] Remote Joystick: Rover responds accurately to remote joystick
- [ ] Autonomous Navigation: Rover navigates to a goal when no teleop commands are sent

### Priority Switching & Preemption
- [ ] Autonomous → Teleop: Joystick input preempts autonomous navigation immediately
- [ ] Teleop → Autonomous: After joystick release + timeout, rover resumes autonomous navigation
- [ ] Local vs. Remote: Higher-priority joystick correctly preempts lower-priority one

### Failsafe & Timeouts
- [ ] Command Timeout: When joystick input stops, `/cmd_vel` output ceases after timeout (rover halts)

### ROS Graph Inspection
- [ ] Using `rqt_graph`, verify:
  - `/local/cmd_vel`, `/remote/cmd_vel`, `/autonomous/cmd_vel` feed into `twist_mux`
  - `twist_mux` is the **only** publisher to final `/cmd_vel`