### PR TITLE
feat(gorm_sensors): add ublox GPS node configuration and launch integration

### DIFF
--- a/src/rover/gorm_sensors/config/zed_f9p.yaml
+++ b/src/rover/gorm_sensors/config/zed_f9p.yaml
@@ -1,0 +1,44 @@
+ublox_gps_node:
+  ros__parameters:
+    debug: 0                    # Range 0-4 (0 means no debug statements will print)
+    device: /dev/ttyACM0
+    frame_id: gps
+    uart1:
+      # The original config requested 460800 which may not be supported by
+      # the host/driver for /dev/ttyACM0 (USB CDC). Trying to set that baud
+      # at startup can fail and cause the node to exit with
+      # 'Could not configure serial baud rate'. Use a safer default here
+      # (115200) or change to the value your system supports. If you want
+      # the node to avoid reconfiguring the device at startup, set
+      # 'config_on_startup' to false (below).
+      baudrate: 38400
+    # If true, node will try to reconfigure the device UART on startup.
+    # Disable this if the device is connected over USB (e.g. /dev/ttyACM0)
+    # and changing the baud via UBX messages or host driver is unsupported.
+    config_on_startup: false
+    gnss:
+      glonass: true
+      beidou: true
+      gps: true
+      qzss: true
+      galileo: true
+      imes: true
+    # TMODE3 Config
+    tmode3: 1                   # Survey-In Mode
+    sv_in:
+      reset: True               # True: disables and re-enables survey-in (resets)
+                                # False: Disables survey-in only if TMODE3 is
+                                # disabled
+      min_dur: 300              # Survey-In Minimum Duration [s]
+      acc_lim: 3.0              # Survey-In Accuracy Limit [m]
+ 
+    inf:
+      all: true                   # Whether to display all INF messages in console
+ 
+    publish:
+      all: false
+      nav:
+        all: true
+        relposned: true
+        posllh: true
+        posecef: true

--- a/src/rover/gorm_sensors/launch/cameras_gnss.launch.py
+++ b/src/rover/gorm_sensors/launch/cameras_gnss.launch.py
@@ -18,22 +18,32 @@ def generate_launch_description():
         launch_arguments={
             'camera_model': 'zed2i',
             'serial_number': '37915676',
-            'zed_id': '0',
+            'camera_id': '0',
             'node_name': 'zed_tracking',
-            'grab_resolution': 'HD720'  # The native camera grab resolution. 'HD2K', 'HD1080', 'HD720', 'VGA', 'AUTO'
+            'grab_resolution': 'HD720', # 'HD720',  # The native camera grab resolution. 'HD2K', 'HD1080', 'HD720', 'VGA', 'AUTO'
+            'gnss_fusion_enabled': 'false',  # Enable GNSS fusion
+            'namespace': 'zed_tracking',  # Namespace for the camera node
+            'initial_base_pose': '[0.28, 0.0, 0.225, 0.0, 0.0, 0.0]',  # Initial pose of the base frame with respect to the camera frame
+            'pos_tracking': 'true',  # Enable positional tracking
+            'publish_tf': 'true',  # Publish TF for the camera
+            'publish_map_tf': 'true',  # Publish map TF for the camera
         }.items()
     )
 
     zed_front = IncludeLaunchDescription(
         PythonLaunchDescriptionSource([
-            FindPackageShare('zed_wrapper'), '/launch/zed_camera.launch.py'
+            FindPackageShare('gorm_sensors'), '/launch/zed_camera.launch.py'
         ]),
         launch_arguments={
             'camera_model': 'zed2i',
             'serial_number': '35803121',
-            'zed_id': '1',
+            'camera_id': '1',
             'node_name': 'zed_front',
-            'grab_resolution': 'VGA'  # The native camera grab resolution. 'HD2K', 'HD1080', 'HD720', 'VGA', 'AUTO'
+            'grab_resolution': 'HD1080', # 'VGA',  # The native camera grab resolution. 'HD2K', 'HD1080', 'HD720', 'VGA', 'AUTO'
+            'pos_tracking': 'false',  # Enable positional tracking
+            'publish_tf': 'false',  # Publish TF for the camera
+            'publish_map_tf': 'false',  # Publish map TF for the camera
+            'namespace': 'zed_front',  # Namespace for the camera node
         }.items()
     )
     static_tf_node = Node(
@@ -51,7 +61,22 @@ def generate_launch_description():
         name='camera_pose',
     )
 
+    params_file = os.path.join(
+        get_package_share_directory('tess_sensors'),
+        'config',
+        'zed_f9p.yaml'
+    )
+
+    ublox_gps_node = Node(
+        package='ublox_gps',
+        executable='ublox_gps_node',
+        name='ublox_gps_node',
+        output='screen',
+        parameters=[params_file],
+    )
+
     ld.add_action(static_tf_node)
     ld.add_action(zed_tracking)
     ld.add_action(zed_front)
+    ld.add_action(ublox_gps_node)
     return ld

--- a/src/rover/gorm_sensors/package.xml
+++ b/src/rover/gorm_sensors/package.xml
@@ -7,6 +7,8 @@
   <maintainer email="antonbm2008@gmail.com">anton</maintainer>
   <license>TODO: License declaration</license>
 
+
+  <exec_depend>ublox_gps</exec_depend>
   <depend>rclpy</depend>
   <depend>geometry_msgs</depend>
   <depend>std_msgs</depend>

--- a/src/rover/gorm_sensors/setup.py
+++ b/src/rover/gorm_sensors/setup.py
@@ -12,7 +12,7 @@ setup(
             ['resource/' + package_name]),
         ('share/' + package_name, ['package.xml']),
         (os.path.join('share', package_name, 'launch'), glob(os.path.join('launch', '*.launch.py'))),
-
+        (os.path.join('share', package_name, 'config'), glob(os.path.join('config', '*.yaml'))),
     ],
     install_requires=['setuptools'],
     zip_safe=True,


### PR DESCRIPTION
This pull request adds GNSS (GPS) sensor integration to the `gorm_sensors` package.

**GNSS (GPS) Integration:**
- Added a new `zed_f9p.yaml` configuration file for the u-blox F9P GPS, specifying device parameters, GNSS settings, and message publishing options.
- Updated the launch file (`cameras_gnss.launch.py`) to include the `ublox_gps_node`, loading parameters from the new configuration file.

**Package Setup Improvements:**
- Modified `setup.py` to install YAML configuration files to the package's share directory.
- Added `ublox_gps` as an execution dependency in `package.xml` to ensure the GPS node is available.

Please adapt device port and frame_id in [zed_f9p.yaml](https://github.com/AAU-Space-Robotics/rover-software/blob/feat/gnss/src/rover/gorm_sensors/config/zed_f9p.yaml) accordingly. Right now they are as follows
<img width="755" height="195" alt="image" src="https://github.com/user-attachments/assets/f131f604-e1b1-4f3d-ad0e-afea694cb8e0" />
